### PR TITLE
Get rid of byErman splash screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq ($(TARGET),3DS)
     BANNER_AUDIO := meta/audio_3ds.wav
     BANNER_IMAGE := meta/banner_3ds.png
     ICON := meta/icon_3ds.png
-    LOGO := meta/logo_3ds.lz11
+    LOGO := 
 endif
 
 # INTERNAL #


### PR DESCRIPTION
This increases boot speed, as the splash doesn't show while loading, but instead prevents loading while it's being shown.